### PR TITLE
Add hasClass and toggleClass to the DOM

### DIFF
--- a/Docs/Dom.md
+++ b/Docs/Dom.md
@@ -153,3 +153,18 @@ Adds new class "className" to all elements of set
 Removes class "className" from all elements of set
 
 	atom.dom('span').removeClass('foo');
+
+
+#### atom.dom().toggleClass(className)
+
+Toggles class "className" for all elements of set
+
+	atom.dom('span').toggleClass('foo');
+
+
+#### atom.dom().hasClass(className)
+
+Returns true if set contains one or more elements
+having class "className"
+
+	atom.dom('span').hasClass('foo');

--- a/Source/Dom.js
+++ b/Source/Dom.js
@@ -266,7 +266,9 @@ new function () {
 			});
 		},
 		removeClass: function (classNames) {
-			if (!isArray(classNames) && classNames) classNames = [classNames];
+            if (!classNames) return this;
+
+			if (!isArray(classNames)) classNames = [classNames];
 
 			return this.each(function (elem) {
 				var current = ' ' + elem.className + ' ';
@@ -276,6 +278,41 @@ new function () {
 				elem.className = current.trim();
 			});
 		},
+        hasClass: function(classNames) {
+            if(!classNames) return false;
+
+            if(!isArray(classNames)) classNames = [classNames];
+
+            var result = false;
+            this.each(function (elem) {
+                var property = elem.className, current = ' ' + property + ' ';
+
+                var elemResult = true;
+                for (var i = classNames.length; i--;) {
+                    elemResult = elemResult && (current.indexOf(' ' + classNames[i] + ' ') >= 0);
+                }
+
+                result = result || elemResult;
+            });
+            return result;
+        },
+        toggleClass: function(classNames) {
+            if(!classNames) return this;
+
+            if(!isArray(classNames)) classNames = [classNames];
+
+            return this.each(function (elem) {
+                var property = elem.className, current = ' ' + property + ' ';
+
+                for (var i = classNames.length; i--;) {
+                    var c = ' ' + classNames[i];
+                    if (current.indexOf(c + ' ') < 0) current = c + current;
+                    else current = current.replace(c + ' ', ' ');
+                }
+
+                elem.className = current.trim();
+            });
+        },
 		log : function () {
 			atom.log.apply(atom, arguments[length] ? arguments : ['atom.dom', this.elems]);
 			return this;


### PR DESCRIPTION
Hello,

atom.dom() plugin is missing two usefull methods: hasClass() and toggleClass().
I tried to implement them using the 'addClass' as a sample.
